### PR TITLE
Add support for MOD

### DIFF
--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -50,7 +50,7 @@ impl Lexer {
     }
 
     fn tokenize_lexeme(&mut self, tokens: &mut Vec<Token>) {
-        let keywords = ["load", "add", "sub", "mul", "div", "ret"];
+        let keywords = ["load", "add", "sub", "mul", "div", "ret", "mod"];
 
         let word = self.lexeme.to_lowercase();
 

--- a/src/tokens/tokens.rs
+++ b/src/tokens/tokens.rs
@@ -7,6 +7,7 @@ pub enum TokenType {
     DIV,
     RET,
     NUM,
+    MOD,
 }
 
 impl TokenType {
@@ -18,6 +19,7 @@ impl TokenType {
             "mul" => Some(TokenType::MUL),
             "div" => Some(TokenType::DIV),
             "ret" => Some(TokenType::RET),
+            "mod" => Some(TokenType::MOD),
             _ => None,
         }
     }
@@ -50,6 +52,7 @@ impl Token {
             TokenType::DIV => 4,
             TokenType::RET => 5,
             TokenType::NUM => self.lexeme.parse::<u8>().unwrap(),
+            TokenType::MOD => 6,
         }
     }
 }


### PR DESCRIPTION
Closes #1 

**Implementation**

1. Define MOD as a token and identify it in the lexical analyzer.
2. Compile MOD to relevant instruction as defined by Yamini VM.