### PR TITLE
Add support for labels and late binding of labels

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -1,21 +1,30 @@
-use crate::tokens::Token;
+use crate::tokens::{Token, TokenType};
+use std::collections::HashMap;
 
 pub struct Compiler {
     tokens: Vec<Token>,
+    label_positions: HashMap<String, usize>,
 }
 
 impl Compiler {
     pub fn new(tokens: Vec<Token>) -> Compiler {
         Compiler {
             tokens,
+            label_positions: HashMap::new(),
         }
     }
 
-    pub fn compile_instructions(&self) -> Vec<u8> {
+    pub fn compile_instructions(&mut self) -> Vec<u8> {
         let mut instructions = Vec::new();
+        let mut num_instructions = 0;
 
         for tok in &self.tokens {
+            if *tok.token() == TokenType::LOADLABEL {
+                self.label_positions.insert(tok.lexeme(), num_instructions);
+            }
+
             instructions.push(tok.to_bytes());
+            num_instructions += 1;
         }
 
         instructions

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -60,6 +60,10 @@ impl Lexer {
                 None => panic!("Unknown token type: {}", word),
             };
             tokens.push(Token::new(token_type, self.lexeme.clone()));
+        } else if word.starts_with("%") {
+            let label_name: String = self.lexeme.as_str()[1..].to_string();
+            let label_token = Token::new(TokenType::LOADLABEL, label_name.clone());
+            tokens.push(label_token);
         } else {
             tokens.push(Token::new(TokenType::NUM, self.lexeme.clone()));
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ fn main() {
 
     let tokens = lexer.tokenize(&file_path);
     
-    let compiler = Compiler::new(tokens);
+    let mut compiler = Compiler::new(tokens);
     
     let instructions = compiler.compile_instructions();
 

--- a/src/tokens/tokens.rs
+++ b/src/tokens/tokens.rs
@@ -8,6 +8,24 @@ pub enum TokenType {
     RET,
     NUM,
     MOD,
+    LOADLABEL,
+}
+
+impl PartialEq for TokenType {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (TokenType::LOAD, TokenType::LOAD) => true,
+            (TokenType::ADD, TokenType::ADD) => true,
+            (TokenType::SUB, TokenType::SUB) => true,
+            (TokenType::MUL, TokenType::MUL) => true,
+            (TokenType::DIV, TokenType::DIV) => true,
+            (TokenType::RET, TokenType::RET) => true,
+            (TokenType::NUM, TokenType::NUM) => true,
+            (TokenType::MOD, TokenType::MOD) => true,
+            (TokenType::LOADLABEL, TokenType::LOADLABEL) => true,
+            _ => false,
+        }
+    }
 }
 
 impl TokenType {
@@ -43,6 +61,10 @@ impl Token {
         &self.token
     }
 
+    pub fn lexeme(&self) -> String {
+        self.lexeme.clone()
+    }
+
     pub fn to_bytes(&self) -> u8 {
         match self.token {
             TokenType::LOAD => 0,
@@ -53,6 +75,7 @@ impl Token {
             TokenType::RET => 5,
             TokenType::NUM => self.lexeme.parse::<u8>().unwrap(),
             TokenType::MOD => 6,
+            TokenType::LOADLABEL => 7,
         }
     }
 }


### PR DESCRIPTION
Closes #3 

**Implementation**

1. Define LOADLABEL token type and identify %"labelname" as a label in lexical analyzer.
2. In the compiler compile LOADLABEL token to the corresponding byte.
3. Maintain a hashmap that contains the mapping from label name to a number of instructions which will help in the late binding of instruction numbers in jump instructions.