### PR TITLE
Add support for JMP instruction, label backpatching

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -1,16 +1,38 @@
-use crate::tokens::{Token, TokenType};
 use std::collections::HashMap;
+
+use crate::tokens::{Token, TokenType};
 
 pub struct Compiler {
     tokens: Vec<Token>,
-    label_positions: HashMap<String, usize>,
+    current_position: usize,
 }
 
 impl Compiler {
     pub fn new(tokens: Vec<Token>) -> Compiler {
         Compiler {
             tokens,
-            label_positions: HashMap::new(),
+            current_position: 0,
+        }
+    }
+
+    fn get_next_token(&mut self) -> &Token {
+        self.current_position += 1;
+        let token = &self.tokens[self.current_position];
+        token
+    }
+
+    fn get_current_token(&self) -> &Token {
+        &self.tokens[self.current_position]
+    }
+
+    fn peek_next_token(&self) -> &Token {
+        &self.tokens[self.current_position + 1]
+    }
+
+    fn expect_next_token(&mut self, token_type: TokenType) {
+        let next_token = self.peek_next_token();
+        if *next_token.token() != token_type {
+            panic!("Expected {:?} but found {:?}", token_type, next_token);
         }
     }
 
@@ -18,15 +40,55 @@ impl Compiler {
         let mut instructions = Vec::new();
         let mut num_instructions = 0;
 
-        for tok in &self.tokens {
-            if *tok.token() == TokenType::LOADLABEL {
-                self.label_positions.insert(tok.lexeme(), num_instructions);
+        let mut label_positions = HashMap::new();
+        let mut backpatch_store = HashMap::new();
+
+        // Pass 1: Compile instructions
+        while self.current_position < self.tokens.len() {
+            let current_token = self.get_current_token();
+
+            match current_token.token() {
+                TokenType::LOAD => {
+                    instructions.push(Some(current_token.to_bytes()));
+                    self.expect_next_token(TokenType::NUM);
+                    let next_token = self.get_next_token();
+                    instructions.push(Some(next_token.to_bytes()));
+                },
+                TokenType::ADD | TokenType::SUB | TokenType::MUL | TokenType::DIV | TokenType::MOD
+                | TokenType::RET => {
+                    instructions.push(Some(current_token.to_bytes()));
+                },
+                TokenType::JMP => {
+                    instructions.push(Some(current_token.to_bytes()));
+                    self.expect_next_token(TokenType::LOADLABEL);
+                    let next_token = self.get_next_token();
+                    instructions.push(None);
+                    backpatch_store.insert(instructions.len() - 1, next_token.lexeme());
+                },
+                TokenType::LOADLABEL => {
+                    instructions.push(Some(current_token.to_bytes()));
+                    label_positions.insert(current_token.lexeme(), num_instructions);
+                }
+                TokenType::NUM => {
+                    panic!("Unexpected token {:?}", current_token);
+                }
             }
 
-            instructions.push(tok.to_bytes());
             num_instructions += 1;
+            self.current_position += 1;
         }
 
-        instructions
+        // Pass 2: Backpatch jumps
+        for (idx, label_name) in backpatch_store {
+            instructions[idx] = Some(label_positions[&label_name] as u8);
+        }
+
+        let mut definitive_instructions = Vec::new();
+
+        for instruction in instructions {
+            definitive_instructions.push(instruction.unwrap());
+        }
+
+        definitive_instructions
     }
 }

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -50,7 +50,7 @@ impl Lexer {
     }
 
     fn tokenize_lexeme(&mut self, tokens: &mut Vec<Token>) {
-        let keywords = ["load", "add", "sub", "mul", "div", "ret", "mod"];
+        let keywords = ["load", "add", "sub", "mul", "div", "ret", "mod", "jmp"];
 
         let word = self.lexeme.to_lowercase();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,13 +27,9 @@ fn main() {
     
     let instructions = compiler.compile_instructions();
 
-    for instruction in &instructions {
-        println!("{}", instruction);
-    }
-
     if Path::new(bin_path).exists() {
         fs::remove_file(bin_path).unwrap();
-      }
+    }
 
     let mut out_file = OpenOptions::new()
         .create_new(true)

--- a/src/tokens/tokens.rs
+++ b/src/tokens/tokens.rs
@@ -9,6 +9,7 @@ pub enum TokenType {
     NUM,
     MOD,
     LOADLABEL,
+    JMP,
 }
 
 impl PartialEq for TokenType {
@@ -23,6 +24,7 @@ impl PartialEq for TokenType {
             (TokenType::NUM, TokenType::NUM) => true,
             (TokenType::MOD, TokenType::MOD) => true,
             (TokenType::LOADLABEL, TokenType::LOADLABEL) => true,
+            (TokenType::JMP, TokenType::JMP) => true,
             _ => false,
         }
     }
@@ -38,6 +40,7 @@ impl TokenType {
             "div" => Some(TokenType::DIV),
             "ret" => Some(TokenType::RET),
             "mod" => Some(TokenType::MOD),
+            "jmp" => Some(TokenType::JMP),
             _ => None,
         }
     }
@@ -76,6 +79,7 @@ impl Token {
             TokenType::NUM => self.lexeme.parse::<u8>().unwrap(),
             TokenType::MOD => 6,
             TokenType::LOADLABEL => 7,
+            TokenType::JMP => 8,
         }
     }
 }

--- a/tests/test_tokens.rs
+++ b/tests/test_tokens.rs
@@ -28,6 +28,9 @@ fn test_token_type_equality() {
 
     let token_type = TokenType::LOADLABEL;
     assert_eq!(token_type, TokenType::LOADLABEL);
+
+    let token_type = TokenType::JMP;
+    assert_eq!(token_type, TokenType::JMP);
 }
 
 #[test]
@@ -52,6 +55,9 @@ fn test_token_from() {
 
     let token_type = TokenType::from("mod");
     assert_eq!(token_type, Some(TokenType::MOD));
+
+    let token_type = TokenType::from("jmp");
+    assert_eq!(token_type, Some(TokenType::JMP));
 
     let token_type = TokenType::from("_");
     assert_eq!(token_type, None);
@@ -97,4 +103,7 @@ fn test_token_to_bytes() {
 
     let token = Token::new(TokenType::LOADLABEL, "loadlabel".to_string());
     assert_eq!(token.to_bytes(), 7);
+
+    let token = Token::new(TokenType::JMP, "jmp".to_string());
+    assert_eq!(token.to_bytes(), 8);
 }


### PR DESCRIPTION
Closes #2 

**Implementation**

1. Identified JMP as an instruction.
2. Implementing the JMP instruction in the compiler was tricky because it requires label backpatching. The first iteration of label backpatching did not work so well. Here's a brief idea of the current version:
     i. There are two different passes, the first pass is over the tokens and does the compilation pretty much similarly, but instead of simply calling the `instruction.to_bytes()` directly, there is a match that handles instructions with arguments. This makes the current compiler also do some basic syntax checking.
    ii. The second pass is responsible for resolving the labels.
    iii. The instructions are set to None in the first pass, and the indexes where data is to be filled and the relevant instruction number for the label are pushed to two different hashmaps - label positions (which hold the label name and the instruction number, this is used to fill the appropriate instruction number to jump to) and backpatch store (which hold the current instruction position and the label name to be resolved, this is used to hold the location where filling of jump result is to be done).