### PR TITLE
Add support for LOADREG instruction

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -71,7 +71,13 @@ impl Compiler {
                 }
                 TokenType::NUM => {
                     panic!("Unexpected token {:?}", current_token);
-                }
+                },
+                TokenType::LOADREGISTER => {
+                    instructions.push(Some(current_token.to_bytes()));
+                    self.expect_next_token(TokenType::NUM);
+                    let next_token = self.get_next_token();
+                    instructions.push(Some(next_token.to_bytes()));
+                },
             }
 
             num_instructions += 1;

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -50,7 +50,8 @@ impl Lexer {
     }
 
     fn tokenize_lexeme(&mut self, tokens: &mut Vec<Token>) {
-        let keywords = ["load", "add", "sub", "mul", "div", "ret", "mod", "jmp"];
+        let keywords = ["load", "add", "sub", "mul", "div", "ret", "mod", "jmp",
+                                 "loadreg"];
 
         let word = self.lexeme.to_lowercase();
 

--- a/src/tokens/tokens.rs
+++ b/src/tokens/tokens.rs
@@ -10,6 +10,7 @@ pub enum TokenType {
     MOD,
     LOADLABEL,
     JMP,
+    LOADREGISTER,
 }
 
 impl PartialEq for TokenType {
@@ -25,6 +26,7 @@ impl PartialEq for TokenType {
             (TokenType::MOD, TokenType::MOD) => true,
             (TokenType::LOADLABEL, TokenType::LOADLABEL) => true,
             (TokenType::JMP, TokenType::JMP) => true,
+            (TokenType::LOADREGISTER, TokenType::LOADREGISTER) => true,
             _ => false,
         }
     }
@@ -41,6 +43,7 @@ impl TokenType {
             "ret" => Some(TokenType::RET),
             "mod" => Some(TokenType::MOD),
             "jmp" => Some(TokenType::JMP),
+            "loadreg" => Some(TokenType::LOADREGISTER),
             _ => None,
         }
     }
@@ -80,6 +83,7 @@ impl Token {
             TokenType::MOD => 6,
             TokenType::LOADLABEL => 7,
             TokenType::JMP => 8,
+            TokenType::LOADREGISTER => 9,
         }
     }
 }

--- a/tests/test_tokens.rs
+++ b/tests/test_tokens.rs
@@ -31,6 +31,9 @@ fn test_token_type_equality() {
 
     let token_type = TokenType::JMP;
     assert_eq!(token_type, TokenType::JMP);
+
+    let token_type = TokenType::LOADREGISTER;
+    assert_eq!(token_type, TokenType::LOADREGISTER);
 }
 
 #[test]
@@ -58,6 +61,9 @@ fn test_token_from() {
 
     let token_type = TokenType::from("jmp");
     assert_eq!(token_type, Some(TokenType::JMP));
+
+    let token_type = TokenType::from("loadreg");
+    assert_eq!(token_type, Some(TokenType::LOADREGISTER));
 
     let token_type = TokenType::from("_");
     assert_eq!(token_type, None);
@@ -106,4 +112,7 @@ fn test_token_to_bytes() {
 
     let token = Token::new(TokenType::JMP, "jmp".to_string());
     assert_eq!(token.to_bytes(), 8);
+
+    let token = Token::new(TokenType::LOADREGISTER, "loadreg".to_string());
+    assert_eq!(token.to_bytes(), 9);
 }


### PR DESCRIPTION
Closes #10 

**Implementation**

1. Identify LOADREG instruction in the lexical analyzer.
2. Compile the LOADREG and the corresponding register number to bytes. 