### PR TITLE
Add JN instruction

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -58,7 +58,7 @@ impl Compiler {
                 | TokenType::RET => {
                     instructions.push(Some(current_token.to_bytes()));
                 },
-                TokenType::JMP | TokenType::JZ => {
+                TokenType::JMP | TokenType::JZ | TokenType::JN => {
                     instructions.push(Some(current_token.to_bytes()));
                     self.expect_next_token(TokenType::LOADLABEL);
                     let next_token = self.get_next_token();

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -51,7 +51,7 @@ impl Lexer {
 
     fn tokenize_lexeme(&mut self, tokens: &mut Vec<Token>) {
         let keywords = ["load", "add", "sub", "mul", "div", "ret", "mod", "jmp",
-                                 "loadreg", "popreg", "jz"];
+                                 "loadreg", "popreg", "jz", "jn"];
 
         let word = self.lexeme.to_lowercase();
 

--- a/src/tokens/tokens.rs
+++ b/src/tokens/tokens.rs
@@ -13,6 +13,7 @@ pub enum TokenType {
     LOADREGISTER,
     POPREGISTER,
     JZ,
+    JN,
 }
 
 impl PartialEq for TokenType {
@@ -31,6 +32,7 @@ impl PartialEq for TokenType {
             (TokenType::LOADREGISTER, TokenType::LOADREGISTER) => true,
             (TokenType::POPREGISTER, TokenType::POPREGISTER) => true,
             (TokenType::JZ, TokenType::JZ) => true,
+            (TokenType::JN, TokenType::JN) => true,
             _ => false,
         }
     }
@@ -50,6 +52,7 @@ impl TokenType {
             "loadreg" => Some(TokenType::LOADREGISTER),
             "popreg" => Some(TokenType::POPREGISTER),
             "jz" => Some(TokenType::JZ),
+            "jn" => Some(TokenType::JN),
             _ => None,
         }
     }
@@ -92,6 +95,7 @@ impl Token {
             TokenType::LOADREGISTER => 9,
             TokenType::POPREGISTER => 10,
             TokenType::JZ => 11,
+            TokenType::JN => 12,
         }
     }
 }

--- a/tests/test_tokens.rs
+++ b/tests/test_tokens.rs
@@ -40,6 +40,9 @@ fn test_token_type_equality() {
 
     let token_type = TokenType::JZ;
     assert_eq!(token_type, TokenType::JZ);
+
+    let token_type = TokenType::JN;
+    assert_eq!(token_type, TokenType::JN);
 }
 
 #[test]
@@ -76,6 +79,9 @@ fn test_token_from() {
 
     let token_type = TokenType::from("jz");
     assert_eq!(token_type, Some(TokenType::JZ));
+
+    let token_type = TokenType::from("jn");
+    assert_eq!(token_type, Some(TokenType::JN));
 
     let token_type = TokenType::from("_");
     assert_eq!(token_type, None);
@@ -133,4 +139,7 @@ fn test_token_to_bytes() {
 
     let token = Token::new(TokenType::JZ, "jz".to_string());
     assert_eq!(token.to_bytes(), 11);
+
+    let token = Token::new(TokenType::JN, "jn".to_string());
+    assert_eq!(token.to_bytes(), 12);
 }


### PR DESCRIPTION
Closes #15 

**Implementation**

1. Identify JN as a keyword in lexer and add it as a new token type.
2. Compiling it is similar to compiling JMP instruction, so merged the code for them into a single match arm. All it does is to compile JN and add the label to backpatch store to be resolved in the next pass. 