### PR TITLE
Reduce instruction set

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -96,6 +96,13 @@ impl Compiler {
                     instructions.push(Some(current_token.to_bytes()));
                     self.expect_next_token(vec![TokenType::REG]);
                     let next_token = self.get_next_token();
+
+                    if next_token.token() == &TokenType::REG {
+                        instructions.push(Some(100)); // Offset to register
+                    } else {
+                        panic!("Expected register");
+                    }
+
                     instructions.push(Some(next_token.to_bytes()));
                 },
             }

--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -29,10 +29,22 @@ impl Compiler {
         &self.tokens[self.current_position + 1]
     }
 
-    fn expect_next_token(&mut self, token_type: TokenType) {
+    fn expect_next_token(&mut self, token_types: Vec<TokenType>) {
         let next_token = self.peek_next_token();
-        if *next_token.token() != token_type {
-            panic!("Expected {:?} but found {:?}", token_type, next_token);
+
+        let mut found = false;
+        let mut expected_token_types = String::new();
+        for token_type in token_types {
+            if next_token.token() == &token_type {
+                found = true;
+                break;
+            } else {
+                expected_token_types.push_str(&format!("{:?} ", token_type));
+            }
+        }
+
+        if !found {
+            panic!("Expected {:?} but found {:?}", expected_token_types, next_token);
         }
     }
 
@@ -50,8 +62,16 @@ impl Compiler {
             match current_token.token() {
                 TokenType::LOAD => {
                     instructions.push(Some(current_token.to_bytes()));
-                    self.expect_next_token(TokenType::NUM);
+                    self.expect_next_token(vec![TokenType::NUM, TokenType::REG]);
                     let next_token = self.get_next_token();
+                    if next_token.token() == &TokenType::NUM {
+                        instructions.push(Some(200)); // Offset to stack
+                    } else if next_token.token() == &TokenType::REG {
+                        instructions.push(Some(100)); // Offset to register
+                    } else {
+                        panic!("Expected register or number");
+                    }
+
                     instructions.push(Some(next_token.to_bytes()));
                 },
                 TokenType::ADD | TokenType::SUB | TokenType::MUL | TokenType::DIV | TokenType::MOD
@@ -60,27 +80,21 @@ impl Compiler {
                 },
                 TokenType::JMP | TokenType::JZ | TokenType::JN => {
                     instructions.push(Some(current_token.to_bytes()));
-                    self.expect_next_token(TokenType::LOADLABEL);
+                    self.expect_next_token(vec![TokenType::LABEL]);
                     let next_token = self.get_next_token();
                     instructions.push(None);
                     backpatch_store.insert(instructions.len() - 1, next_token.lexeme());
                 },
-                TokenType::LOADLABEL => {
+                TokenType::LABEL => {
                     instructions.push(Some(current_token.to_bytes()));
                     label_positions.insert(current_token.lexeme(), num_instructions);
                 }
-                TokenType::NUM => {
+                TokenType::NUM | TokenType::REG => {
                     panic!("Unexpected token {:?}", current_token);
                 },
-                TokenType::LOADREGISTER => {
+                TokenType::POP => {
                     instructions.push(Some(current_token.to_bytes()));
-                    self.expect_next_token(TokenType::NUM);
-                    let next_token = self.get_next_token();
-                    instructions.push(Some(next_token.to_bytes()));
-                },
-                TokenType::POPREGISTER => {
-                    instructions.push(Some(current_token.to_bytes()));
-                    self.expect_next_token(TokenType::NUM);
+                    self.expect_next_token(vec![TokenType::REG]);
                     let next_token = self.get_next_token();
                     instructions.push(Some(next_token.to_bytes()));
                 },

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -51,7 +51,7 @@ impl Lexer {
 
     fn tokenize_lexeme(&mut self, tokens: &mut Vec<Token>) {
         let keywords = ["load", "add", "sub", "mul", "div", "ret", "mod", "jmp",
-                                 "loadreg", "popreg", "jz", "jn"];
+                                 "pop", "jz", "jn"];
 
         let word = self.lexeme.to_lowercase();
 
@@ -63,8 +63,12 @@ impl Lexer {
             tokens.push(Token::new(token_type, self.lexeme.clone()));
         } else if word.starts_with("%") {
             let label_name: String = self.lexeme.as_str()[1..].to_string();
-            let label_token = Token::new(TokenType::LOADLABEL, label_name.clone());
+            let label_token = Token::new(TokenType::LABEL, label_name.clone());
             tokens.push(label_token);
+        } else if word.starts_with("r") {
+            let register_idx = &word[1..];
+            let register_token = Token::new(TokenType::REG, register_idx.to_string());
+            tokens.push(register_token);
         } else {
             tokens.push(Token::new(TokenType::NUM, self.lexeme.clone()));
         }

--- a/src/tokens/tokens.rs
+++ b/src/tokens/tokens.rs
@@ -8,12 +8,12 @@ pub enum TokenType {
     RET,
     NUM,
     MOD,
-    LOADLABEL,
+    LABEL,
     JMP,
-    LOADREGISTER,
-    POPREGISTER,
+    POP,
     JZ,
     JN,
+    REG,
 }
 
 impl PartialEq for TokenType {
@@ -27,12 +27,12 @@ impl PartialEq for TokenType {
             (TokenType::RET, TokenType::RET) => true,
             (TokenType::NUM, TokenType::NUM) => true,
             (TokenType::MOD, TokenType::MOD) => true,
-            (TokenType::LOADLABEL, TokenType::LOADLABEL) => true,
+            (TokenType::LABEL, TokenType::LABEL) => true,
             (TokenType::JMP, TokenType::JMP) => true,
-            (TokenType::LOADREGISTER, TokenType::LOADREGISTER) => true,
-            (TokenType::POPREGISTER, TokenType::POPREGISTER) => true,
+            (TokenType::POP, TokenType::POP) => true,
             (TokenType::JZ, TokenType::JZ) => true,
             (TokenType::JN, TokenType::JN) => true,
+            (TokenType::REG, TokenType::REG) => true,
             _ => false,
         }
     }
@@ -49,8 +49,7 @@ impl TokenType {
             "ret" => Some(TokenType::RET),
             "mod" => Some(TokenType::MOD),
             "jmp" => Some(TokenType::JMP),
-            "loadreg" => Some(TokenType::LOADREGISTER),
-            "popreg" => Some(TokenType::POPREGISTER),
+            "pop" => Some(TokenType::POP),
             "jz" => Some(TokenType::JZ),
             "jn" => Some(TokenType::JN),
             _ => None,
@@ -90,12 +89,12 @@ impl Token {
             TokenType::RET => 5,
             TokenType::NUM => self.lexeme.parse::<u8>().unwrap(),
             TokenType::MOD => 6,
-            TokenType::LOADLABEL => 7,
+            TokenType::LABEL => 7,
             TokenType::JMP => 8,
-            TokenType::LOADREGISTER => 9,
-            TokenType::POPREGISTER => 10,
-            TokenType::JZ => 11,
-            TokenType::JN => 12,
+            TokenType::POP => 9,
+            TokenType::JZ => 10,
+            TokenType::JN => 11,
+            TokenType::REG => self.lexeme.parse::<u8>().unwrap(),
         }
     }
 }

--- a/tests/test_compiler.rs
+++ b/tests/test_compiler.rs
@@ -9,17 +9,26 @@ fn test_compile_instructions() {
     let mut compiler = Compiler::new(tokens);
     let instructions = compiler.compile_instructions();
 
-    assert_eq!(instructions.len(), 11);
+    assert_eq!(instructions.len(), 14);
 
-    assert_eq!(instructions[0], 0);
-    assert_eq!(instructions[1], 4);
-    assert_eq!(instructions[2], 0);
-    assert_eq!(instructions[3], 5);
-    assert_eq!(instructions[4], 1);
-    assert_eq!(instructions[5], 7);
-    assert_eq!(instructions[6], 0);
-    assert_eq!(instructions[7], 2);
-    assert_eq!(instructions[8], 2);
-    assert_eq!(instructions[9], 7);
-    assert_eq!(instructions[10], 5);
+    let expected_instructions: Vec<u8> = vec![
+        0,
+        200,
+        4,
+        0,
+        200,
+        5,
+        1,
+        7,
+        0,
+        200,
+        2,
+        2,
+        7,
+        5,
+    ];
+
+    for (i, instruction) in instructions.iter().enumerate() {
+        assert_eq!(instruction, &expected_instructions[i]);
+    }
 }

--- a/tests/test_lexer.rs
+++ b/tests/test_lexer.rs
@@ -24,7 +24,7 @@ fn test_tokenize_lexeme() {
     assert_eq!(tokens[4].token(), &TokenType::ADD);
     assert_eq!(tokens[4].lexeme(), "ADD");
 
-    assert_eq!(tokens[5].token(), &TokenType::LOADLABEL);
+    assert_eq!(tokens[5].token(), &TokenType::LABEL);
     assert_eq!(tokens[5].lexeme(), "SUB");
 
     assert_eq!(tokens[6].token(), &TokenType::LOAD);
@@ -36,7 +36,7 @@ fn test_tokenize_lexeme() {
     assert_eq!(tokens[8].token(), &TokenType::SUB);
     assert_eq!(tokens[8].lexeme(), "SUB");
 
-    assert_eq!(tokens[9].token(), &TokenType::LOADLABEL);
+    assert_eq!(tokens[9].token(), &TokenType::LABEL);
     assert_eq!(tokens[9].lexeme(), "END");
 
     assert_eq!(tokens[10].token(), &TokenType::RET);

--- a/tests/test_tokens.rs
+++ b/tests/test_tokens.rs
@@ -26,17 +26,14 @@ fn test_token_type_equality() {
     let token_type = TokenType::MOD;
     assert_eq!(token_type, TokenType::MOD);
 
-    let token_type = TokenType::LOADLABEL;
-    assert_eq!(token_type, TokenType::LOADLABEL);
+    let token_type = TokenType::LABEL;
+    assert_eq!(token_type, TokenType::LABEL);
 
     let token_type = TokenType::JMP;
     assert_eq!(token_type, TokenType::JMP);
 
-    let token_type = TokenType::LOADREGISTER;
-    assert_eq!(token_type, TokenType::LOADREGISTER);
-
-    let token_type = TokenType::POPREGISTER;
-    assert_eq!(token_type, TokenType::POPREGISTER);
+    let token_type = TokenType::POP;
+    assert_eq!(token_type, TokenType::POP);
 
     let token_type = TokenType::JZ;
     assert_eq!(token_type, TokenType::JZ);
@@ -71,11 +68,8 @@ fn test_token_from() {
     let token_type = TokenType::from("jmp");
     assert_eq!(token_type, Some(TokenType::JMP));
 
-    let token_type = TokenType::from("loadreg");
-    assert_eq!(token_type, Some(TokenType::LOADREGISTER));
-
-    let token_type = TokenType::from("popreg");
-    assert_eq!(token_type, Some(TokenType::POPREGISTER));
+    let token_type = TokenType::from("pop");
+    assert_eq!(token_type, Some(TokenType::POP));
 
     let token_type = TokenType::from("jz");
     assert_eq!(token_type, Some(TokenType::JZ));
@@ -125,21 +119,18 @@ fn test_token_to_bytes() {
     let token = Token::new(TokenType::MOD, "mod".to_string());
     assert_eq!(token.to_bytes(), 6);
 
-    let token = Token::new(TokenType::LOADLABEL, "loadlabel".to_string());
+    let token = Token::new(TokenType::LABEL, "loadlabel".to_string());
     assert_eq!(token.to_bytes(), 7);
 
     let token = Token::new(TokenType::JMP, "jmp".to_string());
     assert_eq!(token.to_bytes(), 8);
 
-    let token = Token::new(TokenType::LOADREGISTER, "loadreg".to_string());
+    let token = Token::new(TokenType::POP, "popreg".to_string());
     assert_eq!(token.to_bytes(), 9);
 
-    let token = Token::new(TokenType::POPREGISTER, "popreg".to_string());
+    let token = Token::new(TokenType::JZ, "jz".to_string());
     assert_eq!(token.to_bytes(), 10);
 
-    let token = Token::new(TokenType::JZ, "jz".to_string());
-    assert_eq!(token.to_bytes(), 11);
-
     let token = Token::new(TokenType::JN, "jn".to_string());
-    assert_eq!(token.to_bytes(), 12);
+    assert_eq!(token.to_bytes(), 11);
 }


### PR DESCRIPTION
Closes #19 

**Implementation**

1. Remove `LOADREG`, make use of `LOAD` to load to both stack and registers using offset. 
2. Rename `LOADLABEL` to `LABEL`.
3. Make `POPREG` as `POP` and let it generate an offset too (for now it generates 100 always since we can pop values from stack to registers only for now).
4. During compilation both `LOAD` and `POP` instructions generate an appropriate offset based on the next token in YamASM code.