### PR TITLE
Add support for strings

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -61,10 +61,10 @@ impl Compiler {
 
             match current_token.token() {
                 TokenType::LOAD => {
-                    instructions.push(Some(current_token.to_bytes()));
-                    self.expect_next_token(vec![TokenType::NUM, TokenType::REG]);
+                    instructions.append(&mut current_token.to_bytes());
+                    self.expect_next_token(vec![TokenType::NUM, TokenType::REG, TokenType::STARTSTR]);
                     let next_token = self.get_next_token();
-                    if next_token.token() == &TokenType::NUM {
+                    if next_token.token() == &TokenType::NUM || next_token.token() == &TokenType::STARTSTR {
                         instructions.push(Some(200)); // Offset to stack
                     } else if next_token.token() == &TokenType::REG {
                         instructions.push(Some(100)); // Offset to register
@@ -72,28 +72,28 @@ impl Compiler {
                         panic!("Expected register or number");
                     }
 
-                    instructions.push(Some(next_token.to_bytes()));
+                    instructions.append(&mut next_token.to_bytes());
                 },
                 TokenType::ADD | TokenType::SUB | TokenType::MUL | TokenType::DIV | TokenType::MOD
-                | TokenType::RET => {
-                    instructions.push(Some(current_token.to_bytes()));
+                | TokenType::RET | TokenType::ENDSTR | TokenType::STR => {
+                    instructions.append(&mut current_token.to_bytes());
                 },
                 TokenType::JMP | TokenType::JZ | TokenType::JN => {
-                    instructions.push(Some(current_token.to_bytes()));
+                    instructions.append(&mut current_token.to_bytes());
                     self.expect_next_token(vec![TokenType::LABEL]);
                     let next_token = self.get_next_token();
                     instructions.push(None);
                     backpatch_store.insert(instructions.len() - 1, next_token.lexeme());
                 },
                 TokenType::LABEL => {
-                    instructions.push(Some(current_token.to_bytes()));
+                    instructions.append(&mut current_token.to_bytes());
                     label_positions.insert(current_token.lexeme(), num_instructions);
                 }
-                TokenType::NUM | TokenType::REG => {
+                TokenType::NUM | TokenType::REG | TokenType::STARTSTR => {
                     panic!("Unexpected token {:?}", current_token);
                 },
                 TokenType::POP => {
-                    instructions.push(Some(current_token.to_bytes()));
+                    instructions.append(&mut current_token.to_bytes());
                     self.expect_next_token(vec![TokenType::REG]);
                     let next_token = self.get_next_token();
 
@@ -103,7 +103,7 @@ impl Compiler {
                         panic!("Expected register");
                     }
 
-                    instructions.push(Some(next_token.to_bytes()));
+                    instructions.append(&mut next_token.to_bytes());
                 },
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,8 +27,6 @@ fn main() {
     
     let instructions = compiler.compile_instructions();
 
-    println!("{:?}", instructions);
-
     if Path::new(bin_path).exists() {
         fs::remove_file(bin_path).unwrap();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,8 @@ fn main() {
     
     let instructions = compiler.compile_instructions();
 
+    println!("{:?}", instructions);
+
     if Path::new(bin_path).exists() {
         fs::remove_file(bin_path).unwrap();
     }

--- a/src/tokens/tokens.rs
+++ b/src/tokens/tokens.rs
@@ -14,6 +14,9 @@ pub enum TokenType {
     JZ,
     JN,
     REG,
+    STARTSTR,
+    ENDSTR,
+    STR,
 }
 
 impl PartialEq for TokenType {
@@ -33,6 +36,9 @@ impl PartialEq for TokenType {
             (TokenType::JZ, TokenType::JZ) => true,
             (TokenType::JN, TokenType::JN) => true,
             (TokenType::REG, TokenType::REG) => true,
+            (TokenType::STARTSTR, TokenType::STARTSTR) => true,
+            (TokenType::ENDSTR, TokenType::ENDSTR) => true,
+            (TokenType::STR, TokenType::STR) => true,
             _ => false,
         }
     }
@@ -79,22 +85,31 @@ impl Token {
         self.lexeme.clone()
     }
 
-    pub fn to_bytes(&self) -> u8 {
+    pub fn to_bytes(&self) -> Vec<Option<u8>> {
         match self.token {
-            TokenType::LOAD => 0,
-            TokenType::ADD => 1,
-            TokenType::SUB => 2,
-            TokenType::MUL => 3,
-            TokenType::DIV => 4,
-            TokenType::RET => 5,
-            TokenType::NUM => self.lexeme.parse::<u8>().unwrap(),
-            TokenType::MOD => 6,
-            TokenType::LABEL => 7,
-            TokenType::JMP => 8,
-            TokenType::POP => 9,
-            TokenType::JZ => 10,
-            TokenType::JN => 11,
-            TokenType::REG => self.lexeme.parse::<u8>().unwrap(),
+            TokenType::LOAD => vec![Some(0)],
+            TokenType::ADD => vec![Some(1)],
+            TokenType::SUB => vec![Some(2)],
+            TokenType::MUL => vec![Some(3)],
+            TokenType::DIV => vec![Some(4)],
+            TokenType::RET => vec![Some(5)],
+            TokenType::NUM => vec![Some(self.lexeme.parse::<u8>().unwrap())],
+            TokenType::MOD => vec![Some(6)],
+            TokenType::LABEL => vec![Some(7)],
+            TokenType::JMP => vec![Some(8)],
+            TokenType::POP => vec![Some(9)],
+            TokenType::JZ => vec![Some(10)],
+            TokenType::JN => vec![Some(11)],
+            TokenType::REG => vec![Some(self.lexeme.parse::<u8>().unwrap())],
+            TokenType::STARTSTR => vec![Some(12)],
+            TokenType::ENDSTR => vec![Some(13)],
+            TokenType::STR => {
+                let mut bytes = Vec::new();
+                for c in self.lexeme.chars() {
+                    bytes.push(Some(c as u8));
+                }
+                bytes
+            },
         }
     }
 }

--- a/tests/test_tokens.rs
+++ b/tests/test_tokens.rs
@@ -40,6 +40,15 @@ fn test_token_type_equality() {
 
     let token_type = TokenType::JN;
     assert_eq!(token_type, TokenType::JN);
+
+    let token_type = TokenType::STARTSTR;
+    assert_eq!(token_type, TokenType::STARTSTR);
+
+    let token_type = TokenType::ENDSTR;
+    assert_eq!(token_type, TokenType::ENDSTR);
+
+    let token_type = TokenType::STR;
+    assert_eq!(token_type, TokenType::STR);
 }
 
 #[test]
@@ -96,41 +105,50 @@ fn test_token_lexeme_fn() {
 #[test]
 fn test_token_to_bytes() {
     let token = Token::new(TokenType::LOAD, "load".to_string());
-    assert_eq!(token.to_bytes(), 0);
+    assert_eq!(token.to_bytes(), vec![Some(0)]);
 
     let token = Token::new(TokenType::ADD, "add".to_string());
-    assert_eq!(token.to_bytes(), 1);
+    assert_eq!(token.to_bytes(), vec![Some(1)]);
 
     let token = Token::new(TokenType::SUB, "sub".to_string());
-    assert_eq!(token.to_bytes(), 2);
+    assert_eq!(token.to_bytes(), vec![Some(2)]);
 
     let token = Token::new(TokenType::MUL, "mul".to_string());
-    assert_eq!(token.to_bytes(), 3);
+    assert_eq!(token.to_bytes(), vec![Some(3)]);
 
     let token = Token::new(TokenType::DIV, "div".to_string());
-    assert_eq!(token.to_bytes(), 4);
+    assert_eq!(token.to_bytes(), vec![Some(4)]);
 
     let token = Token::new(TokenType::RET, "ret".to_string());
-    assert_eq!(token.to_bytes(), 5);
+    assert_eq!(token.to_bytes(), vec![Some(5)]);
 
     let token = Token::new(TokenType::NUM, "6".to_string());
-    assert_eq!(token.to_bytes(), 6);
+    assert_eq!(token.to_bytes(), vec![Some(6)]);
 
     let token = Token::new(TokenType::MOD, "mod".to_string());
-    assert_eq!(token.to_bytes(), 6);
+    assert_eq!(token.to_bytes(), vec![Some(6)]);
 
     let token = Token::new(TokenType::LABEL, "loadlabel".to_string());
-    assert_eq!(token.to_bytes(), 7);
+    assert_eq!(token.to_bytes(), vec![Some(7)]);
 
     let token = Token::new(TokenType::JMP, "jmp".to_string());
-    assert_eq!(token.to_bytes(), 8);
+    assert_eq!(token.to_bytes(), vec![Some(8)]);
 
     let token = Token::new(TokenType::POP, "popreg".to_string());
-    assert_eq!(token.to_bytes(), 9);
+    assert_eq!(token.to_bytes(), vec![Some(9)]);
 
     let token = Token::new(TokenType::JZ, "jz".to_string());
-    assert_eq!(token.to_bytes(), 10);
+    assert_eq!(token.to_bytes(), vec![Some(10)]);
 
     let token = Token::new(TokenType::JN, "jn".to_string());
-    assert_eq!(token.to_bytes(), 11);
+    assert_eq!(token.to_bytes(), vec![Some(11)]);
+
+    let token = Token::new(TokenType::STARTSTR, "startstr".to_string());
+    assert_eq!(token.to_bytes(), vec![Some(12)]);
+
+    let token = Token::new(TokenType::ENDSTR, "endstr".to_string());
+    assert_eq!(token.to_bytes(), vec![Some(13)]);
+
+    let token = Token::new(TokenType::STR, "Hello".to_string());
+    assert_eq!(token.to_bytes(), vec![Some(72), Some(101), Some(108), Some(108), Some(111)]);
 }


### PR DESCRIPTION
Closes #18 

**Implementation**

1. Add another state in the lexer for reading strings (or other objects of unknown size).
2. Identify `STARTSTR` and `ENDSTR` marker tokens to mark the start and end of a string.
3. Compile string by converting each character to corresponding ASCII value.