### PR TITLE
Add SHOW instruction

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -75,7 +75,7 @@ impl Compiler {
                     instructions.append(&mut next_token.to_bytes());
                 },
                 TokenType::ADD | TokenType::SUB | TokenType::MUL | TokenType::DIV | TokenType::MOD
-                | TokenType::RET | TokenType::ENDSTR | TokenType::STR => {
+                | TokenType::RET | TokenType::ENDSTR | TokenType::STR | TokenType::SHOW => {
                     instructions.append(&mut current_token.to_bytes());
                 },
                 TokenType::JMP | TokenType::JZ | TokenType::JN => {

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -54,7 +54,7 @@ impl Lexer {
 
     fn tokenize_lexeme(&mut self, tokens: &mut Vec<Token>) {
         let keywords = ["load", "add", "sub", "mul", "div", "ret", "mod", "jmp",
-                                 "pop", "jz", "jn"];
+                                 "pop", "jz", "jn", "show"];
 
         let word = self.lexeme.to_lowercase();
 
@@ -72,8 +72,7 @@ impl Lexer {
             let register_idx = &word[1..];
             let register_token = Token::new(TokenType::REG, register_idx.to_string());
             tokens.push(register_token);
-        }
-        else {
+        } else {
             let token_type;
             if self.reading_string {
                 token_type = TokenType::STR;

--- a/src/tokens/tokens.rs
+++ b/src/tokens/tokens.rs
@@ -17,6 +17,7 @@ pub enum TokenType {
     STARTSTR,
     ENDSTR,
     STR,
+    SHOW,
 }
 
 impl PartialEq for TokenType {
@@ -39,6 +40,7 @@ impl PartialEq for TokenType {
             (TokenType::STARTSTR, TokenType::STARTSTR) => true,
             (TokenType::ENDSTR, TokenType::ENDSTR) => true,
             (TokenType::STR, TokenType::STR) => true,
+            (TokenType::SHOW, TokenType::SHOW) => true,
             _ => false,
         }
     }
@@ -58,6 +60,7 @@ impl TokenType {
             "pop" => Some(TokenType::POP),
             "jz" => Some(TokenType::JZ),
             "jn" => Some(TokenType::JN),
+            "show" => Some(TokenType::SHOW),
             _ => None,
         }
     }
@@ -110,6 +113,7 @@ impl Token {
                 }
                 bytes
             },
+            TokenType::SHOW => vec![Some(14)],
         }
     }
 }

--- a/tests/test_tokens.rs
+++ b/tests/test_tokens.rs
@@ -49,6 +49,9 @@ fn test_token_type_equality() {
 
     let token_type = TokenType::STR;
     assert_eq!(token_type, TokenType::STR);
+
+    let token_type = TokenType::SHOW;
+    assert_eq!(token_type, TokenType::SHOW);
 }
 
 #[test]
@@ -85,6 +88,9 @@ fn test_token_from() {
 
     let token_type = TokenType::from("jn");
     assert_eq!(token_type, Some(TokenType::JN));
+
+    let token_type = TokenType::from("show");
+    assert_eq!(token_type, Some(TokenType::SHOW));
 
     let token_type = TokenType::from("_");
     assert_eq!(token_type, None);
@@ -151,4 +157,7 @@ fn test_token_to_bytes() {
 
     let token = Token::new(TokenType::STR, "Hello".to_string());
     assert_eq!(token.to_bytes(), vec![Some(72), Some(101), Some(108), Some(108), Some(111)]);
+
+    let token = Token::new(TokenType::SHOW, "show".to_string());
+    assert_eq!(token.to_bytes(), vec![Some(14)]);
 }


### PR DESCRIPTION
Closes #20 

**Implementation**

1. Add `SHOW` token.
2. Identify it in the lexical analysis phase.
3. Compile it, since it is similar to binary operations and `RET` in its compilation strategy (just compile the single instruction to the binary) thus adding it to the same match arm. 