### PR TITLE
Add implementation of RET and CALL, functions complete

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -75,10 +75,11 @@ impl Compiler {
                     instructions.append(&mut next_token.to_bytes());
                 },
                 TokenType::ADD | TokenType::SUB | TokenType::MUL | TokenType::DIV | TokenType::MOD
-                | TokenType::HALT | TokenType::ENDSTR | TokenType::STR | TokenType::SHOW => {
+                | TokenType::HALT | TokenType::ENDSTR | TokenType::STR | TokenType::SHOW
+                | TokenType::RET => {
                     instructions.append(&mut current_token.to_bytes());
                 },
-                TokenType::JMP | TokenType::JZ | TokenType::JN => {
+                TokenType::JMP | TokenType::JZ | TokenType::JN | TokenType::CALL => {
                     instructions.append(&mut current_token.to_bytes());
                     self.expect_next_token(vec![TokenType::LABEL]);
                     let next_token = self.get_next_token();

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -54,7 +54,7 @@ impl Lexer {
 
     fn tokenize_lexeme(&mut self, tokens: &mut Vec<Token>) {
         let keywords = ["load", "add", "sub", "mul", "div", "halt", "mod", "jmp",
-                                 "pop", "jz", "jn", "show"];
+                                 "pop", "jz", "jn", "show", "ret", "call"];
 
         let word = self.lexeme.to_lowercase();
 

--- a/src/tokens/tokens.rs
+++ b/src/tokens/tokens.rs
@@ -18,6 +18,8 @@ pub enum TokenType {
     ENDSTR,
     STR,
     SHOW,
+    RET,
+    CALL,
 }
 
 impl PartialEq for TokenType {
@@ -41,6 +43,8 @@ impl PartialEq for TokenType {
             (TokenType::ENDSTR, TokenType::ENDSTR) => true,
             (TokenType::STR, TokenType::STR) => true,
             (TokenType::SHOW, TokenType::SHOW) => true,
+            (TokenType::RET, TokenType::RET) => true,
+            (TokenType::CALL, TokenType::CALL) => true,
             _ => false,
         }
     }
@@ -61,6 +65,8 @@ impl TokenType {
             "jz" => Some(TokenType::JZ),
             "jn" => Some(TokenType::JN),
             "show" => Some(TokenType::SHOW),
+            "ret" => Some(TokenType::RET),
+            "call" => Some(TokenType::CALL),
             _ => None,
         }
     }
@@ -114,6 +120,8 @@ impl Token {
                 bytes
             },
             TokenType::SHOW => vec![Some(14)],
+            TokenType::RET => vec![Some(15)],
+            TokenType::CALL => vec![Some(16)],
         }
     }
 }

--- a/tests/test_tokens.rs
+++ b/tests/test_tokens.rs
@@ -52,6 +52,12 @@ fn test_token_type_equality() {
 
     let token_type = TokenType::SHOW;
     assert_eq!(token_type, TokenType::SHOW);
+
+    let token_type = TokenType::RET;
+    assert_eq!(token_type, TokenType::RET);
+
+    let token_type = TokenType::CALL;
+    assert_eq!(token_type, TokenType::CALL);
 }
 
 #[test]
@@ -91,6 +97,12 @@ fn test_token_from() {
 
     let token_type = TokenType::from("show");
     assert_eq!(token_type, Some(TokenType::SHOW));
+
+    let token_type = TokenType::from("ret");
+    assert_eq!(token_type, Some(TokenType::RET));
+
+    let token_type = TokenType::from("call");
+    assert_eq!(token_type, Some(TokenType::CALL));
 
     let token_type = TokenType::from("_");
     assert_eq!(token_type, None);
@@ -160,4 +172,10 @@ fn test_token_to_bytes() {
 
     let token = Token::new(TokenType::SHOW, "show".to_string());
     assert_eq!(token.to_bytes(), vec![Some(14)]);
+
+    let token = Token::new(TokenType::RET, "ret".to_string());
+    assert_eq!(token.to_bytes(), vec![Some(15)]);
+
+    let token = Token::new(TokenType::CALL, "call".to_string());
+    assert_eq!(token.to_bytes(), vec![Some(16)]);
 }


### PR DESCRIPTION
Closes #26

**Implementation**

1. Identify `RET` and `CALL` as tokens in the lexical analyzer.
2. Compile `RET` directly to an instruction, and `CALL` as one of the jump instructions. 