### PR TITLE
EQU implementation

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -60,16 +60,17 @@ impl Compiler {
             let current_token = self.get_current_token();
 
             match current_token.token() {
-                TokenType::LOAD => {
+                TokenType::LOAD | TokenType::EQU => {
                     instructions.append(&mut current_token.to_bytes());
                     self.expect_next_token(vec![TokenType::NUM, TokenType::REG, TokenType::STARTSTR]);
                     let next_token = self.get_next_token();
+
                     if next_token.token() == &TokenType::NUM || next_token.token() == &TokenType::STARTSTR {
                         instructions.push(Some(200)); // Offset to stack
                     } else if next_token.token() == &TokenType::REG {
                         instructions.push(Some(100)); // Offset to register
                     } else {
-                        panic!("Expected register or number");
+                        panic!("Expected register, number or string");
                     }
 
                     instructions.append(&mut next_token.to_bytes());

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -54,7 +54,7 @@ impl Lexer {
 
     fn tokenize_lexeme(&mut self, tokens: &mut Vec<Token>) {
         let keywords = ["load", "add", "sub", "mul", "div", "halt", "mod", "jmp",
-                                 "pop", "jz", "jn", "show", "ret", "call"];
+                                 "pop", "jz", "jn", "show", "ret", "call", "equ"];
 
         let word = self.lexeme.to_lowercase();
 

--- a/src/tokens/tokens.rs
+++ b/src/tokens/tokens.rs
@@ -20,6 +20,7 @@ pub enum TokenType {
     SHOW,
     RET,
     CALL,
+    EQU,
 }
 
 impl PartialEq for TokenType {
@@ -45,6 +46,7 @@ impl PartialEq for TokenType {
             (TokenType::SHOW, TokenType::SHOW) => true,
             (TokenType::RET, TokenType::RET) => true,
             (TokenType::CALL, TokenType::CALL) => true,
+            (TokenType::EQU, TokenType::EQU) => true,
             _ => false,
         }
     }
@@ -67,6 +69,7 @@ impl TokenType {
             "show" => Some(TokenType::SHOW),
             "ret" => Some(TokenType::RET),
             "call" => Some(TokenType::CALL),
+            "equ" => Some(TokenType::EQU),
             _ => None,
         }
     }
@@ -122,6 +125,7 @@ impl Token {
             TokenType::SHOW => vec![Some(14)],
             TokenType::RET => vec![Some(15)],
             TokenType::CALL => vec![Some(16)],
+            TokenType::EQU => vec![Some(17)],
         }
     }
 }

--- a/tests/test_tokens.rs
+++ b/tests/test_tokens.rs
@@ -58,6 +58,9 @@ fn test_token_type_equality() {
 
     let token_type = TokenType::CALL;
     assert_eq!(token_type, TokenType::CALL);
+
+    let token_type = TokenType::EQU;
+    assert_eq!(token_type, TokenType::EQU);
 }
 
 #[test]
@@ -103,6 +106,9 @@ fn test_token_from() {
 
     let token_type = TokenType::from("call");
     assert_eq!(token_type, Some(TokenType::CALL));
+
+    let token_type = TokenType::from("equ");
+    assert_eq!(token_type, Some(TokenType::EQU));
 
     let token_type = TokenType::from("_");
     assert_eq!(token_type, None);
@@ -178,4 +184,7 @@ fn test_token_to_bytes() {
 
     let token = Token::new(TokenType::CALL, "call".to_string());
     assert_eq!(token.to_bytes(), vec![Some(16)]);
+
+    let token = Token::new(TokenType::EQU, "equ".to_string());
+    assert_eq!(token.to_bytes(), vec![Some(17)]);
 }


### PR DESCRIPTION
Closes #28 

**Implementation**

1. Add `EQU` as a token and identify it in the lexical analysis phase.
2. During compilation it is similar to `LOAD` instruction as it requires compiling the offset of the value too based on its argument and hence it is put in the same match arm as `LOAD`. 