### PR TITLE
Add implementation for variables

### DIFF
--- a/src/compiler/constants.rs
+++ b/src/compiler/constants.rs
@@ -1,0 +1,3 @@
+pub(super) const REGISTER_OFFSET: u8 = 1;
+pub(super) const STACK_OFFSET: u8 = 2;
+pub(super) const DATA_MEMORY_OFFSET: u8 = 3;

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -1,3 +1,4 @@
 pub mod compiler;
+mod constants;
 
 pub use compiler::Compiler;

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -14,6 +14,7 @@ pub struct Lexer {
     state: State,
     lexeme: String,
     reading_string: bool,
+    unique_id: Vec<String>,
 }
 
 fn read_file_line_by_line(filepath: &str) -> Result<Vec<char>, Box<dyn std::error::Error>> {
@@ -42,6 +43,7 @@ impl Lexer {
             state: State::START,
             lexeme: String::new(),
             reading_string: false,
+            unique_id: Vec::new(),
         }
     }
 
@@ -72,6 +74,18 @@ impl Lexer {
             let register_idx = &word[1..];
             let register_token = Token::new(TokenType::REG, register_idx.to_string());
             tokens.push(register_token);
+        } else if word.starts_with("&") {
+            let id = &word[1..].to_string();
+            if self.unique_id.contains(id) {
+                let var_id = self.unique_id.iter().position(|x| x == id).unwrap();
+                let var_token = Token::new(TokenType::VAR, var_id.to_string());
+                tokens.push(var_token);
+            } else {
+                self.unique_id.push(id.clone());
+                let var_id = self.unique_id.len() - 1;
+                let var_token = Token::new(TokenType::VAR, var_id.to_string());
+                tokens.push(var_token);
+            }
         } else {
             let token_type;
             if self.reading_string {

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,11 +27,6 @@ fn main() {
     
     let instructions = compiler.compile_instructions();
 
-    if instructions[instructions.len() - 1] != 5 {
-        println!("Error: last instruction must be HALT");
-        return;
-    }
-
     if Path::new(bin_path).exists() {
         fs::remove_file(bin_path).unwrap();
     }

--- a/src/tokens/tokens.rs
+++ b/src/tokens/tokens.rs
@@ -21,6 +21,7 @@ pub enum TokenType {
     RET,
     CALL,
     EQU,
+    VAR,
 }
 
 impl PartialEq for TokenType {
@@ -47,6 +48,7 @@ impl PartialEq for TokenType {
             (TokenType::RET, TokenType::RET) => true,
             (TokenType::CALL, TokenType::CALL) => true,
             (TokenType::EQU, TokenType::EQU) => true,
+            (TokenType::VAR, TokenType::VAR) => true,
             _ => false,
         }
     }
@@ -126,6 +128,7 @@ impl Token {
             TokenType::RET => vec![Some(15)],
             TokenType::CALL => vec![Some(16)],
             TokenType::EQU => vec![Some(17)],
+            TokenType::VAR => vec![Some(self.lexeme.parse::<u8>().unwrap())],
         }
     }
 }

--- a/tests/test_compiler.rs
+++ b/tests/test_compiler.rs
@@ -13,15 +13,15 @@ fn test_compile_instructions() {
 
     let expected_instructions: Vec<u8> = vec![
         0,
-        200,
+        2,
         4,
         0,
-        200,
+        2,
         5,
         1,
         7,
         0,
-        200,
+        2,
         2,
         2,
         7,

--- a/tests/test_tokens.rs
+++ b/tests/test_tokens.rs
@@ -61,6 +61,9 @@ fn test_token_type_equality() {
 
     let token_type = TokenType::EQU;
     assert_eq!(token_type, TokenType::EQU);
+
+    let token_type = TokenType::VAR;
+    assert_eq!(token_type, TokenType::VAR);
 }
 
 #[test]
@@ -187,4 +190,7 @@ fn test_token_to_bytes() {
 
     let token = Token::new(TokenType::EQU, "equ".to_string());
     assert_eq!(token.to_bytes(), vec![Some(17)]);
+
+    let token = Token::new(TokenType::NUM, "0".to_string());
+    assert_eq!(token.to_bytes(), vec![Some(0)]);
 }


### PR DESCRIPTION
Closes #30 

**Implementation**

1. Identify variables (starting with & - ampersand) in the lexical analysis phase. Maintain a vector of unique variable names and if a variable already exists in that list then copy the index into the `VAR` token, otherwise push it to the vector and return the last index of the vector as the index of the `VAR` token.
2. Update offsets to - 1 (register), 2 (stack), and 3 (data memory).
3. During compilation in `LOAD` and `POP` (the two instructions with which variables can be used) compile the offset of data memory as 3 and the actual index processed by the lexical analyzer.