### PR TITLE
Fix: arithmetic with 12/13

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::tokens::{Token, TokenType};
-use super::constants::{REGISTER_OFFSET, STACK_OFFSET, DATA_MEMORY_OFFSET};
+use super::constants::{REGISTER_OFFSET, STACK_OFFSET, STACK_OFFSET_STR, DATA_MEMORY_OFFSET, DATA_MEMORY_OFFSET_STR};
 
 pub struct Compiler {
     tokens: Vec<Token>,
@@ -68,16 +68,25 @@ impl Compiler {
                     let next_token = self.get_next_token();
 
                     if next_token.token() == &TokenType::NUM || next_token.token() == &TokenType::STARTSTR {
-                        instructions.push(Some(STACK_OFFSET)); // Offset to stack
+                        if next_token.token() == &TokenType::STARTSTR {
+                            instructions.push(Some(STACK_OFFSET_STR)); // Offset to stack
+                        } else {
+                            instructions.push(Some(STACK_OFFSET)); // Offset to stack
+                        }
                     } else if next_token.token() == &TokenType::REG {
                         instructions.push(Some(REGISTER_OFFSET)); // Offset to register
                     } else if next_token.token() == &TokenType::VAR {
-                        instructions.push(Some(DATA_MEMORY_OFFSET)); // Offset to data memory
+                        if next_token.token() == &TokenType::STARTSTR {
+                            instructions.push(Some(DATA_MEMORY_OFFSET_STR)); // Offset to data memory
+                        } else {
+                            instructions.push(Some(DATA_MEMORY_OFFSET)); // Offset to data memory
+                        }
                     } else {
                         panic!("Expected register, number or string");
                     }
 
                     instructions.append(&mut next_token.to_bytes());
+
                 },
                 TokenType::ADD | TokenType::SUB | TokenType::MUL | TokenType::DIV | TokenType::MOD
                 | TokenType::HALT | TokenType::ENDSTR | TokenType::STR | TokenType::SHOW
@@ -106,12 +115,17 @@ impl Compiler {
                     if next_token.token() == &TokenType::REG {
                         instructions.push(Some(REGISTER_OFFSET)); // Offset to register
                     } else if next_token.token() == &TokenType::VAR {
-                        instructions.push(Some(DATA_MEMORY_OFFSET)); // Offset to data memory
+                        if next_token.token() == &TokenType::STARTSTR {
+                            instructions.push(Some(DATA_MEMORY_OFFSET_STR)); // Offset to data memory
+                        } else {
+                            instructions.push(Some(DATA_MEMORY_OFFSET)); // Offset to data memory
+                        }
                     } else {
                         panic!("Expected register");
                     }
 
                     instructions.append(&mut next_token.to_bytes());
+
                 },
             }
 

--- a/src/compiler/constants.rs
+++ b/src/compiler/constants.rs
@@ -1,3 +1,5 @@
 pub(super) const REGISTER_OFFSET: u8 = 1;
 pub(super) const STACK_OFFSET: u8 = 2;
-pub(super) const DATA_MEMORY_OFFSET: u8 = 3;
+pub(super) const STACK_OFFSET_STR: u8 = 3;
+pub(super) const DATA_MEMORY_OFFSET: u8 = 4;
+pub(super) const DATA_MEMORY_OFFSET_STR: u8 = 5;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ fn main() {
     let mut lexer = Lexer::new();
 
     let tokens = lexer.tokenize(&file_path);
-    
+
     let mut compiler = Compiler::new(tokens);
     
     let instructions = compiler.compile_instructions();


### PR DESCRIPTION
Closes #32 

**Implementation**

1) Create a separate stack and data memory offset when the constant is an object (for now just of string type). 
2) Stack offset is 2 for integers, for string it is 3, and the respective values for data memory offset are 4 and 5.