### PR TITLE
Add implementation of NEG

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -90,7 +90,7 @@ impl Compiler {
                 },
                 TokenType::ADD | TokenType::SUB | TokenType::MUL | TokenType::DIV | TokenType::MOD
                 | TokenType::HALT | TokenType::ENDSTR | TokenType::STR | TokenType::SHOW
-                | TokenType::RET => {
+                | TokenType::RET | TokenType::NEG => {
                     instructions.append(&mut current_token.to_bytes());
                 },
                 TokenType::JMP | TokenType::JZ | TokenType::JN | TokenType::CALL => {

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -56,7 +56,7 @@ impl Lexer {
 
     fn tokenize_lexeme(&mut self, tokens: &mut Vec<Token>) {
         let keywords = ["load", "add", "sub", "mul", "div", "halt", "mod", "jmp",
-                                 "pop", "jz", "jn", "show", "ret", "call", "equ"];
+                                 "pop", "jz", "jn", "show", "ret", "call", "equ", "neg"];
 
         let word = self.lexeme.to_lowercase();
 

--- a/src/tokens/tokens.rs
+++ b/src/tokens/tokens.rs
@@ -22,6 +22,7 @@ pub enum TokenType {
     CALL,
     EQU,
     VAR,
+    NEG,
 }
 
 impl PartialEq for TokenType {
@@ -49,6 +50,7 @@ impl PartialEq for TokenType {
             (TokenType::CALL, TokenType::CALL) => true,
             (TokenType::EQU, TokenType::EQU) => true,
             (TokenType::VAR, TokenType::VAR) => true,
+            (TokenType::NEG, TokenType::NEG) => true,
             _ => false,
         }
     }
@@ -72,6 +74,7 @@ impl TokenType {
             "ret" => Some(TokenType::RET),
             "call" => Some(TokenType::CALL),
             "equ" => Some(TokenType::EQU),
+            "neg" => Some(TokenType::NEG),
             _ => None,
         }
     }
@@ -129,6 +132,7 @@ impl Token {
             TokenType::CALL => vec![Some(16)],
             TokenType::EQU => vec![Some(17)],
             TokenType::VAR => vec![Some(self.lexeme.parse::<u8>().unwrap())],
+            TokenType::NEG => vec![Some(18)],
         }
     }
 }

--- a/tests/test_tokens.rs
+++ b/tests/test_tokens.rs
@@ -64,6 +64,9 @@ fn test_token_type_equality() {
 
     let token_type = TokenType::VAR;
     assert_eq!(token_type, TokenType::VAR);
+
+    let token_type = TokenType::NEG;
+    assert_eq!(token_type, TokenType::NEG);
 }
 
 #[test]
@@ -112,6 +115,9 @@ fn test_token_from() {
 
     let token_type = TokenType::from("equ");
     assert_eq!(token_type, Some(TokenType::EQU));
+
+    let token_type = TokenType::from("neg");
+    assert_eq!(token_type, Some(TokenType::NEG));
 
     let token_type = TokenType::from("_");
     assert_eq!(token_type, None);
@@ -190,6 +196,9 @@ fn test_token_to_bytes() {
 
     let token = Token::new(TokenType::EQU, "equ".to_string());
     assert_eq!(token.to_bytes(), vec![Some(17)]);
+
+    let token = Token::new(TokenType::NEG, "neg".to_string());
+    assert_eq!(token.to_bytes(), vec![Some(18)]);
 
     let token = Token::new(TokenType::NUM, "0".to_string());
     assert_eq!(token.to_bytes(), vec![Some(0)]);


### PR DESCRIPTION
Closes #34 

**Implementation**

1. Add `NEG` as a token and identify it in the lexer.
2. In the compiler, since it just compiles down to a single instruction without any args, add it to the same match arm as all other no arg instructions. 