### PR TITLE
Add variable address implementation

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -1,7 +1,8 @@
 use std::collections::HashMap;
 
 use crate::tokens::{Token, TokenType};
-use super::constants::{REGISTER_OFFSET, STACK_OFFSET, STACK_OFFSET_STR, DATA_MEMORY_OFFSET, DATA_MEMORY_OFFSET_STR};
+use super::constants::{REGISTER_OFFSET, STACK_OFFSET, STACK_OFFSET_STR, DATA_MEMORY_OFFSET};
+use super::constants::{DATA_MEMORY_OFFSET_STR, ADDR_OFFSET};
 
 pub struct Compiler {
     tokens: Vec<Token>,
@@ -64,7 +65,7 @@ impl Compiler {
                 TokenType::LOAD => {
                     instructions.append(&mut current_token.to_bytes());
                     self.expect_next_token(vec![TokenType::NUM, TokenType::REG, TokenType::STARTSTR,
-                                                           TokenType::VAR]);
+                                                           TokenType::VAR, TokenType::ADDR]);
                     let next_token = self.get_next_token();
 
                     if next_token.token() == &TokenType::NUM || next_token.token() == &TokenType::STARTSTR {
@@ -81,6 +82,8 @@ impl Compiler {
                         } else {
                             instructions.push(Some(DATA_MEMORY_OFFSET)); // Offset to data memory
                         }
+                    } else if next_token.token() == &TokenType::ADDR {
+                        instructions.push(Some(ADDR_OFFSET));
                     } else {
                         panic!("Expected register, number or string");
                     }
@@ -104,7 +107,8 @@ impl Compiler {
                     instructions.append(&mut current_token.to_bytes());
                     label_positions.insert(current_token.lexeme(), num_instructions);
                 }
-                TokenType::NUM | TokenType::REG | TokenType::STARTSTR | TokenType::VAR => {
+                TokenType::NUM | TokenType::REG | TokenType::STARTSTR | TokenType::VAR
+                | TokenType::ADDR => {
                     panic!("Unexpected token {:?}", current_token);
                 },
                 TokenType::POP => {

--- a/src/compiler/constants.rs
+++ b/src/compiler/constants.rs
@@ -3,3 +3,4 @@ pub(super) const STACK_OFFSET: u8 = 2;
 pub(super) const STACK_OFFSET_STR: u8 = 3;
 pub(super) const DATA_MEMORY_OFFSET: u8 = 4;
 pub(super) const DATA_MEMORY_OFFSET_STR: u8 = 5;
+pub(super) const ADDR_OFFSET: u8 = 6;

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -86,6 +86,18 @@ impl Lexer {
                 let var_token = Token::new(TokenType::VAR, var_id.to_string());
                 tokens.push(var_token);
             }
+        } else if word.starts_with("$") {
+            let id = &word[1..].to_string();
+            if self.unique_id.contains(id) {
+                let var_id = self.unique_id.iter().position(|x| x == id).unwrap();
+                let addr_token = Token::new(TokenType::ADDR, var_id.to_string());
+                tokens.push(addr_token);
+            } else {
+                self.unique_id.push(id.clone());
+                let var_id = self.unique_id.len() - 1;
+                let addr_token = Token::new(TokenType::VAR, var_id.to_string());
+                tokens.push(addr_token);
+            }
         } else {
             let token_type;
             if self.reading_string {

--- a/src/tokens/tokens.rs
+++ b/src/tokens/tokens.rs
@@ -23,6 +23,7 @@ pub enum TokenType {
     EQU,
     VAR,
     NEG,
+    ADDR,
 }
 
 impl PartialEq for TokenType {
@@ -51,6 +52,7 @@ impl PartialEq for TokenType {
             (TokenType::EQU, TokenType::EQU) => true,
             (TokenType::VAR, TokenType::VAR) => true,
             (TokenType::NEG, TokenType::NEG) => true,
+            (TokenType::ADDR, TokenType::ADDR) => true,
             _ => false,
         }
     }
@@ -133,6 +135,7 @@ impl Token {
             TokenType::EQU => vec![Some(17)],
             TokenType::VAR => vec![Some(self.lexeme.parse::<u8>().unwrap())],
             TokenType::NEG => vec![Some(18)],
+            TokenType::ADDR => vec![Some(self.lexeme.parse::<u8>().unwrap())],
         }
     }
 }

--- a/tests/test_tokens.rs
+++ b/tests/test_tokens.rs
@@ -67,6 +67,9 @@ fn test_token_type_equality() {
 
     let token_type = TokenType::NEG;
     assert_eq!(token_type, TokenType::NEG);
+
+    let token_type = TokenType::ADDR;
+    assert_eq!(token_type, TokenType::ADDR);
 }
 
 #[test]
@@ -202,4 +205,7 @@ fn test_token_to_bytes() {
 
     let token = Token::new(TokenType::NUM, "0".to_string());
     assert_eq!(token.to_bytes(), vec![Some(0)]);
+
+    let token = Token::new(TokenType::ADDR, "1".to_string());
+    assert_eq!(token.to_bytes(), vec![Some(1)]);
 }


### PR DESCRIPTION
Closes #38 

**Implementation**

1. Identify as `ADDR` token all variables that are preceded by a $ (dollar) symbol. 
2. Compile it similar to var, just change the offset to `ADDR_OFFSET`. 