### PR TITLE
Add implementation of deref

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -93,7 +93,7 @@ impl Compiler {
                 },
                 TokenType::ADD | TokenType::SUB | TokenType::MUL | TokenType::DIV | TokenType::MOD
                 | TokenType::HALT | TokenType::ENDSTR | TokenType::STR | TokenType::SHOW
-                | TokenType::RET | TokenType::NEG | TokenType::EQU => {
+                | TokenType::RET | TokenType::NEG | TokenType::EQU | TokenType::DEREF => {
                     instructions.append(&mut current_token.to_bytes());
                 },
                 TokenType::JMP | TokenType::JZ | TokenType::JN | TokenType::CALL => {

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -56,7 +56,8 @@ impl Lexer {
 
     fn tokenize_lexeme(&mut self, tokens: &mut Vec<Token>) {
         let keywords = ["load", "add", "sub", "mul", "div", "halt", "mod", "jmp",
-                                 "pop", "jz", "jn", "show", "ret", "call", "equ", "neg"];
+                                 "pop", "jz", "jn", "show", "ret", "call", "equ", "neg",
+                                 "deref"];
 
         let word = self.lexeme.to_lowercase();
 

--- a/src/tokens/tokens.rs
+++ b/src/tokens/tokens.rs
@@ -24,6 +24,7 @@ pub enum TokenType {
     VAR,
     NEG,
     ADDR,
+    DEREF,
 }
 
 impl PartialEq for TokenType {
@@ -53,6 +54,7 @@ impl PartialEq for TokenType {
             (TokenType::VAR, TokenType::VAR) => true,
             (TokenType::NEG, TokenType::NEG) => true,
             (TokenType::ADDR, TokenType::ADDR) => true,
+            (TokenType::DEREF, TokenType::DEREF) => true,
             _ => false,
         }
     }
@@ -77,6 +79,7 @@ impl TokenType {
             "call" => Some(TokenType::CALL),
             "equ" => Some(TokenType::EQU),
             "neg" => Some(TokenType::NEG),
+            "deref" => Some(TokenType::DEREF),
             _ => None,
         }
     }
@@ -136,6 +139,7 @@ impl Token {
             TokenType::VAR => vec![Some(self.lexeme.parse::<u8>().unwrap())],
             TokenType::NEG => vec![Some(18)],
             TokenType::ADDR => vec![Some(self.lexeme.parse::<u8>().unwrap())],
+            TokenType::DEREF => vec![Some(19)],
         }
     }
 }

--- a/tests/test_tokens.rs
+++ b/tests/test_tokens.rs
@@ -70,6 +70,9 @@ fn test_token_type_equality() {
 
     let token_type = TokenType::ADDR;
     assert_eq!(token_type, TokenType::ADDR);
+
+    let token_type = TokenType::DEREF;
+    assert_eq!(token_type, TokenType::DEREF);
 }
 
 #[test]
@@ -208,4 +211,7 @@ fn test_token_to_bytes() {
 
     let token = Token::new(TokenType::ADDR, "1".to_string());
     assert_eq!(token.to_bytes(), vec![Some(1)]);
+
+    let token = Token::new(TokenType::DEREF, "deref".to_string());
+    assert_eq!(token.to_bytes(), vec![Some(19)]);
 }


### PR DESCRIPTION
Closes #39 

**Implementation**

1. Add a new token `DEREF` and identify it as a token in the lexer.
2. Compile it similar to all binary/unary operands.