### PR TITLE
Add implementation of PTR

### DIFF
--- a/src/compiler/compiler.rs
+++ b/src/compiler/compiler.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use crate::tokens::{Token, TokenType};
 use super::constants::{REGISTER_OFFSET, STACK_OFFSET, STACK_OFFSET_STR, DATA_MEMORY_OFFSET};
-use super::constants::{DATA_MEMORY_OFFSET_STR, ADDR_OFFSET};
+use super::constants::{DATA_MEMORY_OFFSET_STR, ADDR_OFFSET, PTR_OFFSET};
 
 pub struct Compiler {
     tokens: Vec<Token>,
@@ -108,12 +108,12 @@ impl Compiler {
                     label_positions.insert(current_token.lexeme(), num_instructions);
                 }
                 TokenType::NUM | TokenType::REG | TokenType::STARTSTR | TokenType::VAR
-                | TokenType::ADDR => {
+                | TokenType::ADDR | TokenType::PTR => {
                     panic!("Unexpected token {:?}", current_token);
                 },
                 TokenType::POP => {
                     instructions.append(&mut current_token.to_bytes());
-                    self.expect_next_token(vec![TokenType::REG, TokenType::VAR]);
+                    self.expect_next_token(vec![TokenType::REG, TokenType::VAR, TokenType::PTR]);
                     let next_token = self.get_next_token();
 
                     if next_token.token() == &TokenType::REG {
@@ -124,6 +124,8 @@ impl Compiler {
                         } else {
                             instructions.push(Some(DATA_MEMORY_OFFSET)); // Offset to data memory
                         }
+                    } else if next_token.token() == &TokenType::PTR {
+                        instructions.push(Some(PTR_OFFSET));
                     } else {
                         panic!("Expected register");
                     }

--- a/src/compiler/constants.rs
+++ b/src/compiler/constants.rs
@@ -4,3 +4,4 @@ pub(super) const STACK_OFFSET_STR: u8 = 3;
 pub(super) const DATA_MEMORY_OFFSET: u8 = 4;
 pub(super) const DATA_MEMORY_OFFSET_STR: u8 = 5;
 pub(super) const ADDR_OFFSET: u8 = 6;
+pub(super) const PTR_OFFSET: u8 = 7;

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -99,6 +99,18 @@ impl Lexer {
                 let addr_token = Token::new(TokenType::VAR, var_id.to_string());
                 tokens.push(addr_token);
             }
+        } else if word.starts_with("*") {
+            let id = &word[1..].to_string();
+            if self.unique_id.contains(id) {
+                let var_id = self.unique_id.iter().position(|x| x == id).unwrap();
+                let ptr_token = Token::new(TokenType::PTR, var_id.to_string());
+                tokens.push(ptr_token);
+            } else {
+                self.unique_id.push(id.clone());
+                let var_id = self.unique_id.len() - 1;
+                let ptr_token = Token::new(TokenType::PTR, var_id.to_string());
+                tokens.push(ptr_token);
+            }
         } else {
             let token_type;
             if self.reading_string {

--- a/src/tokens/tokens.rs
+++ b/src/tokens/tokens.rs
@@ -25,6 +25,7 @@ pub enum TokenType {
     NEG,
     ADDR,
     DEREF,
+    PTR,
 }
 
 impl PartialEq for TokenType {
@@ -55,6 +56,7 @@ impl PartialEq for TokenType {
             (TokenType::NEG, TokenType::NEG) => true,
             (TokenType::ADDR, TokenType::ADDR) => true,
             (TokenType::DEREF, TokenType::DEREF) => true,
+            (TokenType::PTR, TokenType::PTR) => true,
             _ => false,
         }
     }
@@ -140,6 +142,7 @@ impl Token {
             TokenType::NEG => vec![Some(18)],
             TokenType::ADDR => vec![Some(self.lexeme.parse::<u8>().unwrap())],
             TokenType::DEREF => vec![Some(19)],
+            TokenType::PTR => vec![Some(self.lexeme.parse::<u8>().unwrap())],
         }
     }
 }

--- a/tests/test_tokens.rs
+++ b/tests/test_tokens.rs
@@ -73,6 +73,9 @@ fn test_token_type_equality() {
 
     let token_type = TokenType::DEREF;
     assert_eq!(token_type, TokenType::DEREF);
+
+    let token_type = TokenType::PTR;
+    assert_eq!(token_type, TokenType::PTR);
 }
 
 #[test]
@@ -214,4 +217,7 @@ fn test_token_to_bytes() {
 
     let token = Token::new(TokenType::DEREF, "deref".to_string());
     assert_eq!(token.to_bytes(), vec![Some(19)]);
+
+    let token = Token::new(TokenType::PTR, "1".to_string());
+    assert_eq!(token.to_bytes(), vec![Some(1)]);
 }


### PR DESCRIPTION
Closes #42 

**Implementation**

1. Identify `PTR` tokens in the lexer, these start with an asterisk (*).
2. During compilation check if it is of type `PTR`, then compile `PTR_OFFSET` in the `POP` opcode. 