### PR TITLE
Use sargparse, add debug flags

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+sargparse = "~0.2.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,31 +1,58 @@
+extern crate sargparse;
+
 use std::fs::{OpenOptions, self};
 use std::io::prelude::*;
 use std::path::Path;
-use std::env;
+use sargparse::{ArgumentParser, ArgumentType, InnerData};
 
 use yamasm::lexer::Lexer;
 use yamasm::compiler::Compiler;
 
 fn main() {
-    let args: Vec<String> = env::args().collect();
-    if args.len() < 2 {
-        println!("Usage: {} <filepath> [<binpath>]", args[0]);
-        return;
-    }
-    let file_path = &args[1];
-    let bin_path = if args.len() > 2 {
-        &args[2]
-    } else {
-        "a.out"
-    };
+    let mut parser = ArgumentParser::new(Some("YamASM - Assembler for YaminiVM"));
+
+    parser.add_argument("f", "file_path", "File path to yas file", 
+                        true, None, ArgumentType::STR);
+    parser.add_argument("-o", "--output", "Output binary file path", 
+                        false, Some(InnerData::STR("a.out".to_string())), ArgumentType::STR);
+    parser.add_argument("-t", "--tokens", "Flag to print tokens",
+                        false, Some(InnerData::BOOL(false)), ArgumentType::BOOL);
+    parser.add_argument("-i", "--instructions", "Flag to print compiled instructions",
+                        false, Some(InnerData::BOOL(false)), ArgumentType::BOOL);
+
+    let args = parser.parse_args().unwrap();
+
+    let file_path = args.get("file_path").unwrap().get_str();
+    let bin_path = &args.get("output").unwrap().get_str();
+
+    let token_flag = args.get("tokens").unwrap().get_bool();
+    let instructions_flag = args.get("instructions").unwrap().get_bool();
 
     let mut lexer = Lexer::new();
 
     let tokens = lexer.tokenize(&file_path);
 
+    if token_flag {
+        println!("--------------------------------------------");
+        println!("Tokens:");
+        for token in &tokens {
+            println!("{:?}", token);
+        }
+        println!("--------------------------------------------");
+    }
+
     let mut compiler = Compiler::new(tokens);
     
     let instructions = compiler.compile_instructions();
+
+    if instructions_flag {
+        println!("--------------------------------------------");
+        println!("Instructions:");
+        for instruction in &instructions {
+            println!("{:?}", instruction);
+        }
+        println!("--------------------------------------------");
+    }
 
     if Path::new(bin_path).exists() {
         fs::remove_file(bin_path).unwrap();


### PR DESCRIPTION
Closes #45 

**Implementation**

1. Move from command line args parsing to using <a href="https://github.com/frankhart2018/sargparse.git">sargparse</a>.
2. Add debug flags - `--tokens` and `--instructions`  for printing the tokens generated and the instructions generated respectively.