### PR TITLE
In 42

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-sargparse = "~0.2.0"
+sargparse = "~0.2.2"

--- a/src/compiler/constants.rs
+++ b/src/compiler/constants.rs
@@ -2,5 +2,5 @@ pub(super) const REGISTER_OFFSET: u8 = 1;
 pub(super) const STACK_OFFSET: u8 = 2;
 pub(super) const STACK_OFFSET_STR: u8 = 3;
 pub(super) const DATA_MEMORY_OFFSET: u8 = 4;
-pub(super) const ADDR_OFFSET: u8 = 6;
-pub(super) const PTR_OFFSET: u8 = 7;
+pub(super) const ADDR_OFFSET: u8 = 5;
+pub(super) const PTR_OFFSET: u8 = 6;

--- a/src/compiler/constants.rs
+++ b/src/compiler/constants.rs
@@ -2,6 +2,5 @@ pub(super) const REGISTER_OFFSET: u8 = 1;
 pub(super) const STACK_OFFSET: u8 = 2;
 pub(super) const STACK_OFFSET_STR: u8 = 3;
 pub(super) const DATA_MEMORY_OFFSET: u8 = 4;
-pub(super) const DATA_MEMORY_OFFSET_STR: u8 = 5;
 pub(super) const ADDR_OFFSET: u8 = 6;
 pub(super) const PTR_OFFSET: u8 = 7;

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -115,8 +115,8 @@ impl Lexer {
             let token_type;
             if self.reading_string {
                 token_type = TokenType::STR;
-                let start_string_token = Token::new(TokenType::STARTSTR, "startstr".to_string());
-                tokens.push(start_string_token);
+                // let start_string_token = Token::new(TokenType::STARTSTR, "startstr".to_string());
+                // tokens.push(start_string_token);
             } else {
                 token_type = TokenType::NUM;
             }
@@ -125,8 +125,8 @@ impl Lexer {
             tokens.push(token);
 
             if self.reading_string {
-                let end_string_token = Token::new(TokenType::ENDSTR, "endstr".to_string());
-                tokens.push(end_string_token);
+                // let end_string_token = Token::new(TokenType::ENDSTR, "endstr".to_string());
+                // tokens.push(end_string_token);
                 self.reading_string = false;
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,6 @@ fn main() {
 
     let file_path = args.get("file_path").unwrap().get_str();
     let bin_path = &args.get("output").unwrap().get_str();
-
     let token_flag = args.get("tokens").unwrap().get_bool();
     let instructions_flag = args.get("instructions").unwrap().get_bool();
 

--- a/src/tokens/tokens.rs
+++ b/src/tokens/tokens.rs
@@ -117,7 +117,18 @@ impl Token {
             TokenType::MUL => vec![Some(3)],
             TokenType::DIV => vec![Some(4)],
             TokenType::HALT => vec![Some(5)],
-            TokenType::NUM => vec![Some(self.lexeme.parse::<u8>().unwrap())],
+            TokenType::NUM => {
+                let mut bytes = Vec::new();
+
+                bytes.push(Some(12)); // STARTSTR marker
+
+                for c in self.lexeme.chars() {
+                    bytes.push(Some(c as u8));
+                }
+
+                bytes.push(Some(13)); // ENDSTR marker
+                bytes
+            },
             TokenType::MOD => vec![Some(6)],
             TokenType::LABEL => vec![Some(7)],
             TokenType::JMP => vec![Some(8)],

--- a/src/tokens/tokens.rs
+++ b/src/tokens/tokens.rs
@@ -129,9 +129,14 @@ impl Token {
             TokenType::ENDSTR => vec![Some(13)],
             TokenType::STR => {
                 let mut bytes = Vec::new();
+
+                bytes.push(Some(12)); // STARTSTR marker
+
                 for c in self.lexeme.chars() {
                     bytes.push(Some(c as u8));
                 }
+
+                bytes.push(Some(13)); // ENDSTR marker
                 bytes
             },
             TokenType::SHOW => vec![Some(14)],

--- a/tests/test_compiler.rs
+++ b/tests/test_compiler.rs
@@ -9,20 +9,26 @@ fn test_compile_instructions() {
     let mut compiler = Compiler::new(tokens);
     let instructions = compiler.compile_instructions();
 
-    assert_eq!(instructions.len(), 14);
+    assert_eq!(instructions.len(), 20);
 
     let expected_instructions: Vec<u8> = vec![
         0,
         2,
-        4,
+        12,
+        52,
+        13,
         0,
         2,
-        5,
+        12,
+        53,
+        13,
         1,
         7,
         0,
         2,
-        2,
+        12,
+        50,
+        13,
         2,
         7,
         5,

--- a/tests/test_tokens.rs
+++ b/tests/test_tokens.rs
@@ -165,7 +165,7 @@ fn test_token_to_bytes() {
     assert_eq!(token.to_bytes(), vec![Some(5)]);
 
     let token = Token::new(TokenType::NUM, "6".to_string());
-    assert_eq!(token.to_bytes(), vec![Some(6)]);
+    assert_eq!(token.to_bytes(), vec![Some(12), Some(54), Some(13)]);
 
     let token = Token::new(TokenType::MOD, "mod".to_string());
     assert_eq!(token.to_bytes(), vec![Some(6)]);
@@ -210,7 +210,7 @@ fn test_token_to_bytes() {
     assert_eq!(token.to_bytes(), vec![Some(18)]);
 
     let token = Token::new(TokenType::NUM, "0".to_string());
-    assert_eq!(token.to_bytes(), vec![Some(0)]);
+    assert_eq!(token.to_bytes(), vec![Some(12), Some(48), Some(13)]);
 
     let token = Token::new(TokenType::ADDR, "1".to_string());
     assert_eq!(token.to_bytes(), vec![Some(1)]);

--- a/tests/test_tokens.rs
+++ b/tests/test_tokens.rs
@@ -192,7 +192,7 @@ fn test_token_to_bytes() {
     assert_eq!(token.to_bytes(), vec![Some(13)]);
 
     let token = Token::new(TokenType::STR, "Hello".to_string());
-    assert_eq!(token.to_bytes(), vec![Some(72), Some(101), Some(108), Some(108), Some(111)]);
+    assert_eq!(token.to_bytes(), vec![Some(12), Some(72), Some(101), Some(108), Some(108), Some(111), Some(13)]);
 
     let token = Token::new(TokenType::SHOW, "show".to_string());
     assert_eq!(token.to_bytes(), vec![Some(14)]);


### PR DESCRIPTION
Closes #42 

**Implementation**

1. Removed `STARTSTR` and `ENDSTR` tokens, and generated these markers directly in the compiler, handling them in the str bytes conversion process. 
2. Compile numbers as u8 character bytes by taking out each character and converting it into its UTF-8 representation. 